### PR TITLE
Bump libuast to v0.2.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PYTHON ?= python3
 
 makefile_dir := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
-LIBUAST_VERSION = v0.2.0
+LIBUAST_VERSION = v0.2.1
 SDK_VERSION = v0
 
 .PHONY : all clean deps

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ libuast_module = Extension(
 setup(
     name="bblfsh",
     description="Fetches Universal Abstract Syntax Trees from Babelfish.",
-    version="0.2.2",
+    version="0.2.3",
     license="Apache 2.0",
     author="source{d}",
     author_email="language-analysis@sourced.tech",


### PR DESCRIPTION
Last version before the upgrade to sdkv1. CI will probably fail (because it'll retrieve the Python driver 0.9.0).