### PR TITLE
Read the file as byte stream as the go client and drivers natively do

### DIFF
--- a/bblfsh/client.py
+++ b/bblfsh/client.py
@@ -32,8 +32,7 @@ class BblfshClient(object):
         self._channel = grpc.insecure_channel(endpoint)
         self._stub = ProtocolServiceStub(self._channel)
 
-    def parse(self, filename, language=None, contents=None, timeout=None,
-              unicode_errors="ignore"):
+    def parse(self, filename, language=None, contents=None, timeout=None):
         """
         Queries the Babelfish server and receives the UAST response for the specified
         file.
@@ -46,8 +45,6 @@ class BblfshClient(object):
         :param contents: The contents of the file. IF None, it is read from \
                          filename.
         :param timeout: The request timeout in seconds.
-        :param unicode_errors: This is passed to open() and changes the way \
-                               Unicode read errors are handled.
         :type filename: str
         :type language: str
         :type contents: str
@@ -59,7 +56,7 @@ class BblfshClient(object):
                 ).ParseRequest
 
         if contents is None:
-            with open(filename, errors=unicode_errors) as fin:
+            with open(filename, "rb") as fin:
                 contents = fin.read()
         request = ParseRequest(filename=os.path.basename(filename),
                                content=contents,

--- a/bblfsh/test.py
+++ b/bblfsh/test.py
@@ -41,7 +41,7 @@ class BblfshTests(unittest.TestCase):
         self._validate_uast(uast)
 
     def testUASTFileContents(self):
-        with open(__file__) as fin:
+        with open(__file__, "rb") as fin:
             contents = fin.read()
         uast = self.client.parse("file.py", contents=contents)
         self._validate_uast(uast)


### PR DESCRIPTION
Fixes bblfsh/java-driver/issues/49.