### PR TITLE
[RFC] Feature/iterator result

### DIFF
--- a/bblfsh/pyuast.c
+++ b/bblfsh/pyuast.c
@@ -163,13 +163,12 @@ static PyObject *PyFilter(PyObject *self, PyObject *args)
       Py_INCREF(node);
       PyList_SET_ITEM(list, i, node);
     }
-
     NodesFree(nodes);
-    return list;
+    return PySeqIter_New(list);
   }
 
   NodesFree(nodes);
-  return PyList_New(0);
+  return PySeqIter_New(PyList_New(0));
 }
 
 static PyMethodDef extension_methods[] = {

--- a/bblfsh/test.py
+++ b/bblfsh/test.py
@@ -56,64 +56,65 @@ class BblfshTests(unittest.TestCase):
     def testFilterInternalType(self):
         node = Node()
         node.internal_type = 'a'
-        self.assertEqual(len(filter(node, "//a")), 1)
-        self.assertEqual(len(filter(node, "//b")), 0)
+        a = filter(node, "//a")
+        self.assertEqual(len(list(filter(node, "//a"))), 1)
+        self.assertEqual(len(list(filter(node, "//b"))), 0)
 
     def testFilterToken(self):
         node = Node()
         node.token = 'a'
-        self.assertEqual(len(filter(node, "//*[@token='a']")), 1)
-        self.assertEqual(len(filter(node, "//*[@token='b']")), 0)
+        self.assertEqual(len(list(filter(node, "//*[@token='a']"))), 1)
+        self.assertEqual(len(list(filter(node, "//*[@token='b']"))), 0)
 
     def testFilterRoles(self):
         node = Node()
         node.roles.append(1)
-        self.assertEqual(len(filter(node, "//*[@roleIdentifier]")), 1)
-        self.assertEqual(len(filter(node, "//*[@roleQualified]")), 0)
+        self.assertEqual(len(list(filter(node, "//*[@roleIdentifier]"))), 1)
+        self.assertEqual(len(list(filter(node, "//*[@roleQualified]"))), 0)
 
     def testFilterProperties(self):
         node = Node()
         node.properties['k1'] = 'v2'
         node.properties['k2'] = 'v1'
-        self.assertEqual(len(filter(node, "//*[@k2='v1']")), 1)
-        self.assertEqual(len(filter(node, "//*[@k1='v2']")), 1)
-        self.assertEqual(len(filter(node, "//*[@k1='v1']")), 0)
+        self.assertEqual(len(list(filter(node, "//*[@k2='v1']"))), 1)
+        self.assertEqual(len(list(filter(node, "//*[@k1='v2']"))), 1)
+        self.assertEqual(len(list(filter(node, "//*[@k1='v1']"))), 0)
 
     def testFilterStartOffset(self):
         node = Node()
         node.start_position.offset = 100
-        self.assertEqual(len(filter(node, "//*[@startOffset=100]")), 1)
-        self.assertEqual(len(filter(node, "//*[@startOffset=10]")), 0)
+        self.assertEqual(len(list(filter(node, "//*[@startOffset=100]"))), 1)
+        self.assertEqual(len(list(filter(node, "//*[@startOffset=10]"))), 0)
 
     def testFilterStartLine(self):
         node = Node()
         node.start_position.line = 10
-        self.assertEqual(len(filter(node, "//*[@startLine=10]")), 1)
-        self.assertEqual(len(filter(node, "//*[@startLine=100]")), 0)
+        self.assertEqual(len(list(filter(node, "//*[@startLine=10]"))), 1)
+        self.assertEqual(len(list(filter(node, "//*[@startLine=100]"))), 0)
 
     def testFilterStartCol(self):
         node = Node()
-        node.start_position.col= 50
-        self.assertEqual(len(filter(node, "//*[@startCol=50]")), 1)
-        self.assertEqual(len(filter(node, "//*[@startCol=5]")), 0)
+        node.start_position.col = 50
+        self.assertEqual(len(list(filter(node, "//*[@startCol=50]"))), 1)
+        self.assertEqual(len(list(filter(node, "//*[@startCol=5]"))), 0)
 
     def testFilterEndOffset(self):
         node = Node()
         node.end_position.offset = 100
-        self.assertEqual(len(filter(node, "//*[@endOffset=100]")), 1)
-        self.assertEqual(len(filter(node, "//*[@endOffset=10]")), 0)
+        self.assertEqual(len(list(filter(node, "//*[@endOffset=100]"))), 1)
+        self.assertEqual(len(list(filter(node, "//*[@endOffset=10]"))), 0)
 
     def testFilterEndLine(self):
         node = Node()
         node.end_position.line = 10
-        self.assertEqual(len(filter(node, "//*[@endLine=10]")), 1)
-        self.assertEqual(len(filter(node, "//*[@endLine=100]")), 0)
+        self.assertEqual(len(list(filter(node, "//*[@endLine=10]"))), 1)
+        self.assertEqual(len(list(filter(node, "//*[@endLine=100]"))), 0)
 
     def testFilterEndCol(self):
         node = Node()
         node.end_position.col = 50
-        self.assertEqual(len(filter(node, "//*[@endCol=50]")), 1)
-        self.assertEqual(len(filter(node, "//*[@endCol=5]")), 0)
+        self.assertEqual(len(list(filter(node, "//*[@endCol=50]"))), 1)
+        self.assertEqual(len(list(filter(node, "//*[@endCol=5]"))), 0)
 
     def _validate_uast(self, uast):
         self.assertIsNotNone(uast)
@@ -124,8 +125,7 @@ class BblfshTests(unittest.TestCase):
         self.assertIsInstance(uast.uast, Node)
 
     def _validate_filter(self, uast):
-        results = filter(uast.uast, "//Import[@roleImport and @roleDeclaration]//alias")
-        self.assertEqual(len(results), 3)
+        results = list(filter(uast.uast, "//Import[@roleImport and @roleDeclaration]//alias"))
         self.assertEqual(results[0].token, "unittest")
         self.assertEqual(results[1].token, "importlib")
 

--- a/bblfsh/test.py
+++ b/bblfsh/test.py
@@ -56,65 +56,64 @@ class BblfshTests(unittest.TestCase):
     def testFilterInternalType(self):
         node = Node()
         node.internal_type = 'a'
-        a = filter(node, "//a")
-        self.assertEqual(len(list(filter(node, "//a"))), 1)
-        self.assertEqual(len(list(filter(node, "//b"))), 0)
+        self.assertTrue(any(filter(node, "//a")))
+        self.assertFalse(any(filter(node, "//b")))
 
     def testFilterToken(self):
         node = Node()
         node.token = 'a'
-        self.assertEqual(len(list(filter(node, "//*[@token='a']"))), 1)
-        self.assertEqual(len(list(filter(node, "//*[@token='b']"))), 0)
+        self.assertTrue(any(filter(node, "//*[@token='a']")))
+        self.assertFalse(any(filter(node, "//*[@token='b']")))
 
     def testFilterRoles(self):
         node = Node()
         node.roles.append(1)
-        self.assertEqual(len(list(filter(node, "//*[@roleIdentifier]"))), 1)
-        self.assertEqual(len(list(filter(node, "//*[@roleQualified]"))), 0)
+        self.assertTrue(any(filter(node, "//*[@roleIdentifier]")))
+        self.assertFalse(any(filter(node, "//*[@roleQualified]")))
 
     def testFilterProperties(self):
         node = Node()
         node.properties['k1'] = 'v2'
         node.properties['k2'] = 'v1'
-        self.assertEqual(len(list(filter(node, "//*[@k2='v1']"))), 1)
-        self.assertEqual(len(list(filter(node, "//*[@k1='v2']"))), 1)
-        self.assertEqual(len(list(filter(node, "//*[@k1='v1']"))), 0)
+        self.assertTrue(any(filter(node, "//*[@k2='v1']")))
+        self.assertTrue(any(filter(node, "//*[@k1='v2']")))
+        self.assertFalse(any(filter(node, "//*[@k1='v1']")))
 
     def testFilterStartOffset(self):
         node = Node()
         node.start_position.offset = 100
-        self.assertEqual(len(list(filter(node, "//*[@startOffset=100]"))), 1)
-        self.assertEqual(len(list(filter(node, "//*[@startOffset=10]"))), 0)
+        self.assertTrue(any(filter(node, "//*[@startOffset=100]")))
+        self.assertFalse(any(filter(node, "//*[@startOffset=10]")))
 
     def testFilterStartLine(self):
         node = Node()
         node.start_position.line = 10
-        self.assertEqual(len(list(filter(node, "//*[@startLine=10]"))), 1)
-        self.assertEqual(len(list(filter(node, "//*[@startLine=100]"))), 0)
+        self.assertTrue(any(filter(node, "//*[@startLine=10]")))
+        self.assertFalse(any(filter(node, "//*[@startLine=100]")))
 
     def testFilterStartCol(self):
         node = Node()
         node.start_position.col = 50
-        self.assertEqual(len(list(filter(node, "//*[@startCol=50]"))), 1)
-        self.assertEqual(len(list(filter(node, "//*[@startCol=5]"))), 0)
+        self.assertTrue(any(filter(node, "//*[@startCol=50]")))
+        self.assertFalse(any(filter(node, "//*[@startCol=5]")))
 
     def testFilterEndOffset(self):
         node = Node()
         node.end_position.offset = 100
-        self.assertEqual(len(list(filter(node, "//*[@endOffset=100]"))), 1)
-        self.assertEqual(len(list(filter(node, "//*[@endOffset=10]"))), 0)
+        self.assertTrue(any(filter(node, "//*[@endOffset=100]")))
+        self.assertFalse(any(filter(node, "//*[@endOffset=10]")))
 
     def testFilterEndLine(self):
         node = Node()
         node.end_position.line = 10
-        self.assertEqual(len(list(filter(node, "//*[@endLine=10]"))), 1)
-        self.assertEqual(len(list(filter(node, "//*[@endLine=100]"))), 0)
+        self.assertTrue(any(filter(node, "//*[@endLine=10]")))
+        self.assertFalse(any(filter(node, "//*[@endLine=100]")))
 
     def testFilterEndCol(self):
         node = Node()
         node.end_position.col = 50
-        self.assertEqual(len(list(filter(node, "//*[@endCol=50]"))), 1)
-        self.assertEqual(len(list(filter(node, "//*[@endCol=5]"))), 0)
+        self.assertTrue(any(filter(node, "//*[@endCol=50]")))
+        self.assertFalse(any(filter(node, "//*[@endCol=5]")))
 
     def _validate_uast(self, uast):
         self.assertIsNotNone(uast)
@@ -125,9 +124,9 @@ class BblfshTests(unittest.TestCase):
         self.assertIsInstance(uast.uast, Node)
 
     def _validate_filter(self, uast):
-        results = list(filter(uast.uast, "//Import[@roleImport and @roleDeclaration]//alias"))
-        self.assertEqual(results[0].token, "unittest")
-        self.assertEqual(results[1].token, "importlib")
+        results = filter(uast.uast, "//Import[@roleImport and @roleDeclaration]//alias")
+        self.assertEqual(next(results).token, "unittest")
+        self.assertEqual(next(results).token, "importlib")
 
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ libuast_module = Extension(
 setup(
     name="bblfsh",
     description="Fetches Universal Abstract Syntax Trees from Babelfish.",
-    version="2.1.0",
+    version="2.2.0",
     license="Apache 2.0",
     author="source{d}",
     author_email="language-analysis@sourced.tech",


### PR DESCRIPTION
From #29.

Changes `filter()` to return an iterator object instead of a list. This goes in line with what most Python 3.x APIs do. It also breaks any code doing a `len(result)` or `result[index]` which would have to be changed to `len(list(result))`, `list(result)[0]` or `any(result)` to check if there is any element. 

This was agreed as a good thing on the linked issue but I think we should get feedback from other Python client users before merging.