### PR TITLE
Bugfixes

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,3 +5,6 @@ include LICENSE
 include MAINTAINERS
 include Makefile
 include github.com/gogo/protobuf/gogoproto/gogo.proto
+include gopkg.in/bblfsh/sdk.v1/protocol/generated.proto
+include gopkg.in/bblfsh/sdk.v1/uast/generated.proto
+prune bblfsh/libuast

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,4 @@ include DCO
 include LICENSE
 include MAINTAINERS
 include Makefile
+include github.com/gogo/protobuf/gogoproto/gogo.proto

--- a/bblfsh/__main__.py
+++ b/bblfsh/__main__.py
@@ -29,7 +29,7 @@ def setup():
     return args
 
 def run_query(root, query, mapn, as_array):
-    result = filter(root, query)
+    result = list(filter(root, query))
 
     if not result:
         print("Nothing found")


### PR DESCRIPTION
- Use an extension setuptools command for getting libuast which is more proper.
- Remove bblfsh/libuast in manifest since it wont download anything if the directory already exists.
- Add the proto files in the manifest.