### PR TITLE
Test for issue 60 + bblfshd/libuast update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## client-python [![Build Status](https://travis-ci.org/bblfsh/client-python.svg?branch=master)](https://travis-ci.org/bblfsh/client-python) [![PyPI](https://img.shields.io/pypi/v/bblfsh.svg)](https://pypi.python.org/pypi/bblfsh)
 
 [Babelfish](https://doc.bblf.sh) Python client library provides functionality to both
-connect to the Babelfish server to parse code
+connect to the Babelfish bblfshd to parse code
 (obtaining an [UAST](https://doc.bblf.sh/uast/specification.html) as a result)
 and to analyse UASTs with the functionality provided by [libuast](https://github.com/bblfsh/libuast).
 
@@ -37,10 +37,11 @@ A small example of how to parse a Python file and extract the import declaration
 If you don't have a bblfsh server running you can execute it using the following command:
 
 ```sh
-docker run --privileged --rm -it -p 9432:9432 --name bblfsh bblfsh/server
+docker run --privileged --rm -it -p 9432:9432 -v bblfsh_cache:/var/lib/bblfshd --name bblfshd bblfsh/bblfshd
+docker exec -it bblfshd bblfshctl driver install python bblfsh/python-driver:latest
 ```
 
-Please, read the [getting started](https://doc.bblf.sh/user/getting-started.html) guide to learn more about how to use and deploy a bblfsh server.
+Please, read the [getting started](https://doc.bblf.sh/user/getting-started.html) guide to learn more about how to use and deploy a bblfshd.
 
 ```python
 from bblfsh import BblfshClient, filter

--- a/bblfsh/fixtures/issue60.py
+++ b/bblfsh/fixtures/issue60.py
@@ -1,0 +1,33 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="apollo",
+    description="source{d} Gemini's evil twin which runs everything using Python.",
+    version="0.1.0",
+    license="Apache 2.0",
+    author="source{d}",
+    author_email="machine-learning@sourced.tech",
+    url="https://github.com/src-d/gemini",
+    download_url="https://github.com/src-d/gemini",
+    packages=find_packages(exclude=("gemini.tests",)),
+    entry_points={
+        "console_scripts": ["gemini=gemini.__main__:main"],
+    },
+    keywords=["machine learning on source code", "weighted minhash", "minhash",
+              "bblfsh", "babelfish"],
+    install_requires=["cassandra_driver >= 3.12.0, <4.0",
+                      "libMHCUDA >= 1.1.5, <2.0"],
+                      # "sourcedml >= 0.4.0, <1.0"],
+    package_data={"": ["LICENSE", "README.md"]},
+    classifiers=[
+        "Development Status :: 3 - Alpha",
+        "Environment :: Console",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: POSIX",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Topic :: Software Development :: Libraries"
+    ]
+)

--- a/bblfsh/test.py
+++ b/bblfsh/test.py
@@ -142,6 +142,7 @@ class BblfshTests(unittest.TestCase):
 
     def _validate_filter(self, resp):
         results = filter(resp.uast, "//Import[@roleImport and @roleDeclaration]//alias")
+        self.assertEqual(next(results).token, "os")
         self.assertEqual(next(results).token, "unittest")
         self.assertEqual(next(results).token, "docker")
 

--- a/bblfsh/test.py
+++ b/bblfsh/test.py
@@ -17,7 +17,7 @@ class BblfshTests(unittest.TestCase):
     def tearDownClass(cls):
         if not cls.BBLFSH_SERVER_EXISTED:
             client = docker.from_env(version="auto")
-            client.containers.get("bblfsh").remove(force=True)
+            client.containers.get("bblfshd").remove(force=True)
             client.api.close()
 
     def setUp(self):
@@ -111,6 +111,15 @@ class BblfshTests(unittest.TestCase):
         node.end_position.col = 50
         self.assertTrue(any(filter(node, "//*[@endCol=50]")))
         self.assertFalse(any(filter(node, "//*[@endCol=5]")))
+
+    def testFilterBadQuery(self):
+        node = Node()
+        self.assertRaises(RuntimeError, filter, node, "//*roleModule")
+
+    def testIssue60(self):
+        rep = self.client.parse("fixtures/issue60.py")
+        assert(rep.uast)
+        self.assertFalse(any(filter(rep.uast, "//@roleLiteral")))
 
     def testRoleIdName(sedlf):
         assert(role_id(role_name(1)) == 1)

--- a/bblfsh/test.py
+++ b/bblfsh/test.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 
 import docker
@@ -117,7 +118,10 @@ class BblfshTests(unittest.TestCase):
         self.assertRaises(RuntimeError, filter, node, "//*roleModule")
 
     def testIssue60(self):
-        rep = self.client.parse("fixtures/issue60.py")
+        fixtures_dir = os.path.join(
+                        os.path.dirname(os.path.realpath(__file__)),
+                        "fixtures")
+        rep = self.client.parse(os.path.join(fixtures_dir, "issue60.py"))
         assert(rep.uast)
         self.assertFalse(any(filter(rep.uast, "//@roleLiteral")))
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import sys
 from setuptools import setup, find_packages, Extension
 from setuptools.command.build_ext import build_ext
 
-LIBUAST_VERSION = "v1.4.1"
+LIBUAST_VERSION = "v1.5.0"
 SDK_VERSION = "v1.8.0"
 SDK_MAJOR = SDK_VERSION.split('.')[0]
 PYTHON = "python3"
@@ -23,7 +23,7 @@ class CustomBuildExt(build_ext):
         if "--global-uast" in sys.argv:
             libraries.append('uast')
         else:
-            sources.append('bblfsh/libuast/uast.c')
+            sources.append('bblfsh/libuast/uast.cc')
             sources.append('bblfsh/libuast/roles.c')
 
         getLibuast()
@@ -123,7 +123,7 @@ def main():
         'bblfsh.pyuast',
         libraries=libraries,
         library_dirs=['/usr/lib', '/usr/local/lib'],
-        extra_compile_args=['-std=gnu99'],
+        extra_compile_args=['-std=c++11'],
         include_dirs=['bblfsh/libuast/', '/usr/local/include', '/usr/local/include/libxml2',
                       '/usr/include', '/usr/include/libxml2'], sources=sources)
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,8 @@ SDK_VERSION = "v1.8.0"
 SDK_MAJOR = SDK_VERSION.split('.')[0]
 PYTHON = "python3"
 
-
+os.environ["CC"] = "g++"
+os.environ["CXX"] = "g++"
 libraries = ['xml2']
 sources = ['bblfsh/pyuast.c']
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import sys
 from setuptools import setup, find_packages, Extension
 from setuptools.command.build_ext import build_ext
 
-LIBUAST_VERSION = "v1.5.0"
+LIBUAST_VERSION = "v1.5.1"
 SDK_VERSION = "v1.8.0"
 SDK_MAJOR = SDK_VERSION.split('.')[0]
 PYTHON = "python3"


### PR DESCRIPTION
Fixes #60 (was really fixed on libuast). 

- Test and fixture for issue 60.
- Update libuast dependency to 1.5.0, compile with C++11 standard.
- Tests: Use bblfshd + driver install instead of the server.
- Update `README.md`.

Note: CI will fail until bblfsh/libuast/pull/54 is merged. After that merge I'll update the libuast dependency version.

Signed-off-by: Juanjo Alvarez <juanjo@sourced.tech>