### PR TITLE
fix memory leak: add Py_DECREF to non-returned owned references

### DIFF
--- a/bblfsh/pyuast.c
+++ b/bblfsh/pyuast.c
@@ -26,13 +26,8 @@ static size_t Size(const void *node, const char *prop) {
 }
 
 static PyObject *ItemAt(PyObject *object, int index) {
-  PyObject *retval = NULL;
   PyObject *seq = PySequence_Fast(object, "expected a sequence");
-  if (seq != NULL) {
-    retval = PyList_GET_ITEM(seq, index);
-    Py_DECREF(seq);
-  }
-  return retval;
+  return PyList_GET_ITEM(seq, index);
 }
 
 

--- a/bblfsh/pyuast.c
+++ b/bblfsh/pyuast.c
@@ -26,8 +26,13 @@ static size_t Size(const void *node, const char *prop) {
 }
 
 static PyObject *ItemAt(PyObject *object, int index) {
+  PyObject *retval = NULL;
   PyObject *seq = PySequence_Fast(object, "expected a sequence");
-  return PyList_GET_ITEM(seq, index);
+  if (seq != NULL) {
+    retval = PyList_GET_ITEM(seq, index);
+    Py_DECREF(seq);
+  }
+  return retval;
 }
 
 
@@ -38,7 +43,6 @@ static const char *InternalType(const void *node) {
 static const char *Token(const void *node) {
   return String(node, "token");
 }
-
 static size_t ChildrenSize(const void *node) {
   return Size(node, "children");
 }
@@ -68,8 +72,13 @@ static const char *PropertyKeyAt(const void *node, int index) {
     return NULL;
   }
 
+  const char *retval = NULL;
   PyObject *keys = PyMapping_Keys(properties);
-  return keys ? PyUnicode_AsUTF8(ItemAt(keys, index)) : NULL;
+  if (keys != NULL) {
+    retval = PyUnicode_AsUTF8(ItemAt(keys, index));
+    Py_DECREF(keys);
+  }
+  return retval;
 }
 
 static const char *PropertyValueAt(const void *node, int index) {
@@ -78,8 +87,13 @@ static const char *PropertyValueAt(const void *node, int index) {
     return NULL;
   }
 
+  const char *retval = NULL;
   PyObject *values = PyMapping_Values(properties);
-  return values ? PyUnicode_AsUTF8(ItemAt(values, index)) : NULL;
+  if (values != NULL) {
+    retval = PyUnicode_AsUTF8(ItemAt(values, index));
+    Py_DECREF(values);
+  }
+  return retval;
 }
 
 static uint32_t PositionValue(const void* node, const char *prop, const char *field) {
@@ -275,7 +289,9 @@ static PyObject *PyFilter(PyObject *self, PyObject *args)
     PyList_SET_ITEM(list, i, node);
   }
   NodesFree(nodes);
-  return PySeqIter_New(list);
+  PyObject *iter = PySeqIter_New(list);
+  Py_DECREF(list);
+  return iter;
 }
 
 static PyMethodDef extension_methods[] = {

--- a/bblfsh/test.py
+++ b/bblfsh/test.py
@@ -195,5 +195,19 @@ class BblfshTests(unittest.TestCase):
         self.assertEqual(next(results).token, "docker")
 
 
+    def testManyFilters(self):
+        root = self.client.parse(__file__).uast
+        root.properties['k1'] = 'v2'
+        root.properties['k2'] = 'v1'
+
+        import resource
+        before = resource.getrusage(resource.RUSAGE_SELF)
+        for _ in range(100):
+            filter(root, "//*[@roleIdentifier]")
+        after = resource.getrusage(resource.RUSAGE_SELF)
+
+        # Check that memory usage has not doubled after running the filter
+        self.assertLess(after[2] / before[2], 2.0)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
There are a few memory leaks in `pyuast.c` when objects are owned by a function, used, and not returned. I've been doing some benchmarking and here's a comparison of memory usage / objects. I've also added a unit test which can be used to test for memory leaks in the `filter` function (for now, it just considers memory usage doubling to be a leak).

_Note: these numbers are based on a [patched libuast](https://github.com/bblfsh/libuast/pull/75) which fixes a different leak._

### Before

```
Iterations: 500
Memory ratio: 8.742483577564427
        types |   # objects |   total size
============= | =========== | ============
  <class list |     4128542 |    467.09 MB
   <class str |        8099 |    528.04 KB
  <class dict |         560 |    120.05 KB
```

### After

```
Iterations: 500
Memory ratio: 1.0705486410972822
        types |   # objects |   total size
============= | =========== | ============
  <class list |        5542 |    507.60 KB
   <class str |        5093 |    363.70 KB
  <class dict |         560 |    120.05 KB
```

---

_Memory stats obtained via `pympler`:_
```python
from pympler.tracker import SummaryTracker
tracker = SummaryTracker()
# work()
tracker.print_diff()
```