### PR TITLE
Fix leaks in HasPosition calls

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import setup, find_packages, Extension
 from setuptools.command.build_ext import build_ext
 
-VERSION = "2.9.11"
+VERSION = "2.9.12"
 LIBUAST_VERSION = "v1.9.1"
 SDK_VERSION = "v1.8.0"
 SDK_MAJOR = SDK_VERSION.split('.')[0]
@@ -76,9 +76,9 @@ def getLibuast():
     if not GET_LIBUAST:
         return
 
-    runc("curl -SL https://github.com/bblfsh/libuast/releases/download/{LIBUAST_VERSION}/"
-         "libuast-{LIBUAST_VERSION}.tar.gz | tar xz")
-    runc("mv libuast-{LIBUAST_VERSION} libuast")
+    runc("curl -SL https://github.com/bblfsh/libuast/archive/{LIBUAST_VERSION}/"
+         "{LIBUAST_VERSION}.tar.gz | tar xz")
+    runc("mv {} libuast".format('libuast-' + LIBUAST_VERSION.replace('v', '')))
     runc("cp -a libuast/src bblfsh/libuast")
     runc("rm -rf libuast")
 


### PR DESCRIPTION
Fixes #100.

- Fix calls in the "HasXXX" position functions to `AttributeValue` without decreasing the reference of the returned object or adding it to the memory tracker which were leaking in a specific case

- Added ugly warnings about the need to do that on `Attribute` and `AttributeValue`.

- Added two new tests for memleaks covering the bug.

- Updated the build to the latest libuast and changed URL.

Signed-off-by: Juanjo Alvarez <juanjo@sourced.tech>