### PR TITLE
HasAttribute: Ensure no py_decref is called on a null pointer

### DIFF
--- a/bblfsh/pyuast.cc
+++ b/bblfsh/pyuast.cc
@@ -30,9 +30,12 @@ static PyObject *AttributeValue(const void *node, const char *prop) {
 
 static bool HasAttribute(const void *node, const char *prop) {
   PyObject *o = AttributeValue(node, prop);
-  bool res = o != NULL;
+  if (o == NULL) {
+    return false;
+  }
+
   Py_DECREF(o);
-  return res;
+  return true;
 }
 
 static const char *String(const void *node, const char *prop) {

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import setup, find_packages, Extension
 from setuptools.command.build_ext import build_ext
 
-VERSION = "2.9.12"
+VERSION = "2.9.13"
 LIBUAST_VERSION = "v1.9.1"
 SDK_VERSION = "v1.8.0"
 SDK_MAJOR = SDK_VERSION.split('.')[0]


### PR DESCRIPTION
Small change for yesterday PR to ensure not calling `Py_DECREF` on a NULL pointer.

Signed-off-by: Juanjo Alvarez <juanjo@sourced.tech>