### PR TITLE
Use version range for grpcio instead of exact version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -272,7 +272,7 @@ def main():
         packages=find_packages(),
         exclude=["bblfsh/test.py"],
         keywords=["babelfish", "uast"],
-        install_requires=["grpcio==1.13.0", "grpcio-tools==1.13.0", "docker", "protobuf>=3.4.0"],
+        install_requires=["grpcio>=1.13.0,<2.0", "grpcio-tools>=1.13.0,<2.0", "docker", "protobuf>=3.4.0"],
         package_data={"": ["LICENSE", "README.md"]},
         ext_modules=[libuast_module],
         classifiers=[


### PR DESCRIPTION
Fixed version of grpcio is causing error when an application needs to use
newer compatible grpcio:
bblfsh 2.11.2 has requirement grpcio==1.13.0, but you'll have grpcio 1.17.0
which is incompatible.

In my case I stumbled on this bug that is fixed in newer grpcio:
https://github.com/grpc/grpc/issues/14088

Signed-off-by: Maxim Sukharev <max@smacker.ru>