### PR TITLE
Remove an obsolete docstring annotation.

### DIFF
--- a/bblfsh/client.py
+++ b/bblfsh/client.py
@@ -68,7 +68,6 @@ class BblfshClient:
         :param contents: The contents of the file. IF None, it is read from \
                          filename.
         :param mode:     UAST transformation mode.
-        :param raw:      Return raw binary UAST without decoding it.
         :param timeout: The request timeout in seconds.
         :type filename: str
         :type language: str


### PR DESCRIPTION
The `raw` parameter was removed from `parse` in bd8c2d57, but we forgot to drop
the doc string for it.

Fixes #143.

Signed-off-by: M. J. Fromberger <michael.j.fromberger@gmail.com>