### PR TITLE
Require Python ≥ 3.6.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -336,8 +336,6 @@ def main():
             "Intended Audience :: Developers",
             "License :: OSI Approved :: Apache Software License",
             "Operating System :: POSIX",
-            "Programming Language :: Python :: 3.4",
-            "Programming Language :: Python :: 3.5",
             "Programming Language :: Python :: 3.6",
             "Programming Language :: Python :: 3.7",
             "Topic :: Software Development :: Libraries"


### PR DESCRIPTION
Some of our code uses type annotations on variable declarations, which were introduced by [PEP 526](https://www.python.org/dev/peps/pep-0526/) with Python 3.6. There does not seem to be any good reason not to prefer newer versions of Python 3, since we are already incompatible with Python 2, so this change drops the 3.4 and 3.5 tags from the PyPI configuration.

Fixes #153.
