### PR TITLE
Include a python_requires clause in the setup file.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -326,6 +326,7 @@ def main():
         packages=find_packages(),
         exclude=["bblfsh/test.py"],
         keywords=["babelfish", "uast"],
+        python_requires='>=3.6',
         install_requires=["grpcio>=1.13.0", "grpcio-tools>=1.13.0",
                           "docker", "protobuf>=3.4.0"],
         package_data={"": ["LICENSE", "README.md"]},


### PR DESCRIPTION
This is a follow-up to #154. Recent versions of setuptools allow specifying [explicit version constraints][1] for Python. Older versions will ignore it, but it can't hurt.

[1]: https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires
